### PR TITLE
Remove unnecessary check for existing cert, due to certbot handles by…

### DIFF
--- a/.platform/hooks/postdeploy/00_ssl_setup_certbot.sh
+++ b/.platform/hooks/postdeploy/00_ssl_setup_certbot.sh
@@ -61,14 +61,6 @@ if ! grep -Fxq "$NAME_LIMIT" /etc/nginx/nginx.conf; then
     fi
 fi
 
-# Prevent certificate installation if not clean sample app
-
-CERT_REGEX="Certificate Name:\s+$CERTBOT_NAME"
-
-if certbot certificates | grep -Ew "$CERT_REGEX"; then
-    log_and_exit 'INFO: Certificate already installed.'
-fi
-
 # Set up certificates
 
 if command -v certbot &>/dev/null; then


### PR DESCRIPTION
The code sample can be found here:

https://github.com/certbot/certbot/blob/7f0fa18c570942238a7de73ed99945c3710408b4/certbot/certbot/_internal/main.py#L288

I have to make this change, due to AWS Eb resetting Nginx conf each time.
Since `certbot` handles cert check by itself, I think it's useful to move the decision to outside.

